### PR TITLE
Update Chevrotain syntax for defining rules.

### DIFF
--- a/lib/xdr_parser.js
+++ b/lib/xdr_parser.js
@@ -87,7 +87,7 @@ class XdrParser extends Parser {
     const $ = this;
 
     // RULES
-    $.typespec_declaration = $.RULE('typespec_declaration', () => {
+    $.RULE('typespec_declaration', () => {
       let type = $.SUBRULE($.type_specifier);
       $.OPTION(() => $.CONSUME(Asterisk));
       let name = $.CONSUME(Identifier).image;
@@ -112,7 +112,7 @@ class XdrParser extends Parser {
         { type: type, name: name };
     });
 
-    $.opaque_declaration = $.RULE('opaque_declaration', () => {
+    $.RULE('opaque_declaration', () => {
       let declaration = $.OR([
         // "opaque" identifier "[" value "]"
         { ALT: () => {
@@ -138,7 +138,7 @@ class XdrParser extends Parser {
       return declaration;
     });
 
-    $.declaration = $.RULE('declaration', () => {
+    $.RULE('declaration', () => {
       let declaration = $.OR([
         { ALT: () => $.SUBRULE($.typespec_declaration) },
         { ALT: () => $.SUBRULE($.opaque_declaration) },
@@ -164,7 +164,7 @@ class XdrParser extends Parser {
     });
 
     // constant | identifier
-    $.value = $.RULE('value', () => {
+    $.RULE('value', () => {
       let value = $.OR([
         { ALT: () => $.SUBRULE($.constant) },
         { ALT: () => $.CONSUME(Identifier) }
@@ -174,7 +174,7 @@ class XdrParser extends Parser {
     });
 
     // decimal-constant | hexadecimal-constant | octal-constant
-    $.constant = $.RULE('constant', () => {
+    $.RULE('constant', () => {
       let value = $.OR([
         { ALT: () => $.CONSUME(HexConstant) },
         { ALT: () => $.CONSUME(OctalConstant) },
@@ -184,7 +184,7 @@ class XdrParser extends Parser {
       return value.image;
     });
 
-    $.type_specifier = $.RULE('type_specifier', () => {
+    $.RULE('type_specifier', () => {
       let type = $.OR([
         // [ "unsigned" ] "int"
         { ALT: () => {
@@ -238,13 +238,13 @@ class XdrParser extends Parser {
       return type;
     });
 
-    $.enum_type_spec = $.RULE('enum_type_spec', () => {
+    $.RULE('enum_type_spec', () => {
       let type = $.CONSUME(Enum).image;
       let members = $.SUBRULE($.enum_body);
       return { type: type, members: members };
     });
 
-    $.enum_body = $.RULE('enum_body', () => {
+    $.RULE('enum_body', () => {
       let members = [];
       $.CONSUME(LBrace);
       $.MANY_SEP(Comma, () => {
@@ -257,13 +257,13 @@ class XdrParser extends Parser {
       return members;
     });
 
-    $.struct_type_spec = $.RULE('struct_type_spec', () => {
+    $.RULE('struct_type_spec', () => {
       let type = $.CONSUME(Struct).image;
       let members = $.SUBRULE($.struct_body);
       return { type: type, members: members };
     });
 
-    $.struct_body = $.RULE('struct_body', () => {
+    $.RULE('struct_body', () => {
       let members = [];
       $.CONSUME(LBrace);
       $.MANY(() => {
@@ -275,13 +275,13 @@ class XdrParser extends Parser {
       return members;
     });
 
-    $.union_type_spec = $.RULE('union_type_spec', () => {
+    $.RULE('union_type_spec', () => {
       let type = $.CONSUME(Union);
       let members = $.SUBRULE($.union_body);
       return { type: type, members: members };
     });
 
-    $.union_body = $.RULE('union_body', () => {
+    $.RULE('union_body', () => {
       let type = 'union';
       $.CONSUME(Switch);
       $.CONSUME(LParen);
@@ -296,7 +296,7 @@ class XdrParser extends Parser {
       return { type: type, name: name, members: members };
     });
 
-    $.case_spec = $.RULE('case_spec', () => {
+   $.RULE('case_spec', () => {
       let cases = [];
       $.MANY(() => {
         let type = $.CONSUME(Case).image;
@@ -309,7 +309,7 @@ class XdrParser extends Parser {
       return { type: 'case', cases: cases, declaration: decl };
     });
 
-    $.constant_def = $.RULE('constant_def', () => {
+    $.RULE('constant_def', () => {
       let type = $.CONSUME(Const).image;
       let name = $.CONSUME(Identifier).image;
       $.CONSUME(Equals);
@@ -322,7 +322,7 @@ class XdrParser extends Parser {
       return { type: type, name: name, value: value };
     });
 
-    $.type_def = $.RULE('type_def', () => {
+    $.RULE('type_def', () => {
       let name, type, members;
 
       $.OR([
@@ -359,7 +359,7 @@ class XdrParser extends Parser {
     });
 
     // type-def | constant-def
-    $.definition = $.RULE('definition', () => {
+    $.RULE('definition', () => {
       let result = $.OR([
         { ALT: () => $.SUBRULE($.type_def) },
         { ALT: () => $.SUBRULE2($.constant_def) }
@@ -368,7 +368,7 @@ class XdrParser extends Parser {
       return result;
     });
 
-    $.specification = $.RULE('specification', () => {
+    $.RULE('specification', () => {
       let result = [];
       $.MANY(() => {
         let definition = $.SUBRULE($.definition);


### PR DESCRIPTION
The duplication in the rule name is no longer required.
I've also updated to tutorial to demonstrate this.